### PR TITLE
remove empty list created in read_core_folder_zip. it was instantiate…

### DIFF
--- a/safegraph_py_functions/safegraph_py_functions.py
+++ b/safegraph_py_functions/safegraph_py_functions.py
@@ -185,8 +185,6 @@ def read_core_folder(path_to_core, compression='gzip',*args, **kwargs):
 def read_core_folder_zip(path_to_core, compression='gzip', *args, **kwargs):
     zip_file = ZipFile(path_to_core)
 
-    li = []
-
     dfs = {text_file.filename: pd.read_csv(zip_file.open(text_file.filename), compression=compression, dtype={'postal_code': str, 'phone_number': str, 'naics_code': str}, *args, **kwargs)
            for text_file in zip_file.infolist()
            if text_file.filename.endswith('.csv.gz')}


### PR DESCRIPTION
…d but never appended to. the unused variable was throwing an error. The intent is to tidy and eliminate potential for confusion.