### PR TITLE
Updated test functions in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ pip install -q --upgrade git+https://github.com/SafeGraphInc/safegraph_py
 ```python
 from safegraph_py_functions import safegraph_py_functions as sgpy
 
-sgpy.test_me() # returns 'Hello World' to ensure you have downloaded the library
-sgpy.help() # returns a list of all active functions and their arguments in the safegraph_py library
+sgpy.test_me_sgpy() # returns 'Hello World' to ensure you have downloaded the library
+sgpy.help_sgpy() # returns a list of all active functions and their arguments in the safegraph_py library
 sgpy.read_pattern_single(f_path) # returns a Pandas DF from a single patterns file
 # etc. . . 
 ```


### PR DESCRIPTION
The names of the test functions were changed, but the readme wasn't updated with the new names.

This should hopefully fix issue #35

Note: If this package is installed using "pip install safegraph_py" the test function names are still `help()` and `test_me()`
